### PR TITLE
Enable pkgdown website

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: r
 sudo: required
 dist: trusty
+cache: packages
+warnings_are_errors: false
+
+apt_packages:
+  - libgmp3-dev
+
+before_cache: Rscript -e 'remotes::install_cran("pkgdown")'
 
 before_install:
   - cd pkg
@@ -8,19 +15,16 @@ before_install:
 r:
   - release
   - devel
-
-os:
-  - linux
   
 matrix:
   include:
     - r: release
       os: osx
+    - r: release
+      os: linux
 
-apt_packages:
-  - libgmp3-dev
-
-cache: packages
-
-warnings_are_errors: false
+deploy:
+  provider: script
+  script: Rscript -e 'pkgdown::deploy_site_github()'
+  skip_cleanup: true
 

--- a/pkg/_pkgdown.yml
+++ b/pkg/_pkgdown.yml
@@ -1,0 +1,1 @@
+destination: docs


### PR DESCRIPTION
With this PR I've added everything to get a functional website at https://frmunoz.github.io/ecolottery/ but for it to work what is needed is that @frmunoz adds the deploy key to both its GitHub and Travis account as specified on the [pkgown website](https://pkgdown.r-lib.org/reference/deploy_site_github.html).
The easiest way to do this is to use the `travis` R package using the following command:

```r
travis::use_travis_deploy()
```

I've already created an empty `gh-pages` branch ;)